### PR TITLE
Add other user auth types (basic auth and api token) and add users autocomplete endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,60 @@ The Zendesk NodeJS SDK provides a wrapper around the Zendesk V2 REST JSON API.
 
 Documentation for the API can be found at: https://developer.zendesk.com/rest_api/docs/zendesk-apis/resources
 
+The Zendesk API is rate limited. To see how many requests per minute is allowed please refer to Zendesk's documentation [here](https://developer.zendesk.com/rest_api/docs/support/introduction#rate-limits).
+
+https://developer.zendesk.com/rest_api/docs/support/introduction#rate-limits
+
 Zendesk Resources are declared under `lib/resources/**.js`, and will be injected into the `lib/api/index.js` object, which is then exported from `lib/index.js`.
+
+### Requirements
+ - [Node.js](https://nodejs.org/en/) v8 (may work with previous versions but not supported)
 
 ### Installation
 `yarn add zendesk-node`
-
 
 ### Libraries used
 * [Node.js](https://nodejs.org/en/)
 * [Jest](https://jestjs.io/)
 * [Nock](https://github.com/nock/nock)
 
-
 ### Creating an API Object
+
+> You must be a verified user to make API requests. You can authorize against the API using either basic authentication with your email address and password, with your email address and an API token, or with an OAuth access token. - [Zendesk Documentation](https://developer.zendesk.com/rest_api/docs/support/introduction#security-and-authentication)
+
+#### Basic authentication
+
+> If an agent or admin has enabled 2-factor authentication in their user profile, they won't be able to use basic authentication. Alternatives include using an API token or implementing an OAuth flow. [Learn more](https://develop.zendesk.com/hc/en-us/articles/360001074508). - [Zendesk Documentation](https://developer.zendesk.com/rest_api/docs/support/introduction#basic-authentication)
+
+```js
+const Zendesk = require('zendesk-node');
+
+const email = 'AGENT_S_EMAIL_ADDRESS';
+const password = 'AGENT_S_PASSWORD';
+const zendeskSubdomain = 'ZENDESK_SUBDOMAIN';
+const zendesk = Zendesk({ zendeskSubdomain, email, password });
+```
+
+#### API token
+
+```js
+const Zendesk = require('zendesk-node');
+
+const email = 'AGENT_S_EMAIL_ADDRESS';
+const zendeskSubdomain = 'ZENDESK_SUBDOMAIN';
+const zendeskAdminToken = 'API_TOKEN'; // Login to your Zendesk's Agent and go to Admin -> API to generate.
+const zendesk = Zendesk({ zendeskSubdomain, email, zendeskAdminToken });
+```
+
+#### Oauth access token
 Currently the API expects that you have curled your own admin token.
 
-```
-const Zendesk = require('zendesk-node')
+```js
+const Zendesk = require('zendesk-node');
 
-const zendeskSubdomain = 'hostmakersupport';
-const zendeskAdminToken = 'adminToken';
-const zendesk = Zendesk({ zendeskSubdomain, zendeskAdminToken })
+const zendeskSubdomain = 'ZENDESK_SUBDOMAIN';
+const zendeskAdminToken = 'OAUTH_ACCESS_TOKEN';
+const zendesk = Zendesk({ zendeskSubdomain, zendeskAdminToken });
 ```
 
 ### Querying the API
@@ -38,27 +71,27 @@ Notes:
 
 
 #### GET
-```
+```js
 const ticket = await zendesk.tickets.get(42, { /* GET params */ });
 ```
 
 #### LIST
-```
+```js
 const tickets = await zendesk.tickets.list({ /* GET params */ });
 ```
 
 #### CREATE
-```
+```js
 const ticket = await zendesk.tickets.create({/* POST data */});
 ```
 
 #### UPDATE
-```
+```js
 const ticket = await zendesk.tickets.update(42, {/* POST data */});
 ```
 
 #### DELETE
-```
+```js
 await zendesk.tickets.delete(42);
 ```
 
@@ -67,10 +100,15 @@ The Zendesk API is large, and not all API resources have been implemented yet.
 
 Currently supported resources include:
 
-#### Tickets:
- - Get
- - List
- - Create
- - Update
- - Delete
- - ListComments
+#### Tickets
+ - [Show Ticket](https://developer.zendesk.com/rest_api/docs/support/tickets#show-ticket)
+ - [List Tickets](https://developer.zendesk.com/rest_api/docs/support/tickets#list-tickets)
+ - [Create Ticket](https://developer.zendesk.com/rest_api/docs/support/tickets#create-ticket)
+ - [Update Ticket](https://developer.zendesk.com/rest_api/docs/support/tickets#update-ticket)
+ - [Delete Ticket](https://developer.zendesk.com/rest_api/docs/support/tickets#delete-ticket)
+
+#### Ticket comments
+ - [List Comments](https://developer.zendesk.com/rest_api/docs/support/ticket_comments#list-comments)
+
+#### Users
+ - [Autocomplete Users](https://developer.zendesk.com/rest_api/docs/support/users#autocomplete-users)

--- a/README.md
+++ b/README.md
@@ -35,30 +35,32 @@ const Zendesk = require('zendesk-node');
 const email = 'AGENT_S_EMAIL_ADDRESS';
 const password = 'AGENT_S_PASSWORD';
 const zendeskSubdomain = 'ZENDESK_SUBDOMAIN';
-const zendesk = Zendesk({ zendeskSubdomain, email, password });
+const zendesk = Zendesk({ authType: AUTH_TYPES.BASIC_AUTH, zendeskSubdomain, email, password });
 ```
 
 #### API token
 
 ```js
-const Zendesk = require('zendesk-node');
+const Zendesk, { AUTH_TYPES } = require('zendesk-node');
 
 const email = 'AGENT_S_EMAIL_ADDRESS';
 const zendeskSubdomain = 'ZENDESK_SUBDOMAIN';
 const zendeskAdminToken = 'API_TOKEN'; // Login to your Zendesk's Agent and go to Admin -> API to generate.
-const zendesk = Zendesk({ zendeskSubdomain, email, zendeskAdminToken });
+const zendesk = Zendesk({ authType: AUTH_TYPES.API_TOKEN, zendeskSubdomain, email, zendeskAdminToken });
 ```
 
 #### Oauth access token
 Currently the API expects that you have curled your own admin token.
 
 ```js
-const Zendesk = require('zendesk-node');
+const Zendesk, { AUTH_TYPES } = require('zendesk-node');
 
 const zendeskSubdomain = 'ZENDESK_SUBDOMAIN';
 const zendeskAdminToken = 'OAUTH_ACCESS_TOKEN';
-const zendesk = Zendesk({ zendeskSubdomain, zendeskAdminToken });
+const zendesk = Zendesk({ authType: AUTH_TYPES.OAUTH_ACCESS_TOKEN, zendeskSubdomain, zendeskAdminToken });
 ```
+
+Note: if `authType` is omitted the sdk defaults to oauth access token method.
 
 ### Querying the API
 

--- a/lib/api/auth.js
+++ b/lib/api/auth.js
@@ -1,0 +1,23 @@
+const { Base64 } = require('js-base64');
+
+const AUTH_TYPES = {
+  BASIC_AUTH: 'BASIC_AUTH',
+  API_TOKEN: 'API_TOKEN',
+  OAUTH_ACCESS_TOKEN: 'OAUTH_ACCESS_TOKEN',
+};
+
+function createAuthorizationHeaderValue(config) {
+  const { authType, email, password, zendeskAdminToken } = config;
+
+  switch (authType) {
+    case AUTH_TYPES.BASIC_AUTH:
+      return `Basic ${Base64.btoa(`${email}:${password}`)}`;
+    case AUTH_TYPES.API_TOKEN:
+      return `Basic ${Base64.btoa(`${email}/token:${zendeskAdminToken}`)}`;
+    default:
+    case AUTH_TYPES.OAUTH_ACCESS_TOKEN:
+      return `Bearer ${zendeskAdminToken}`;
+  }
+}
+
+module.exports = { createAuthorizationHeaderValue, AUTH_TYPES };

--- a/lib/api/auth.test.js
+++ b/lib/api/auth.test.js
@@ -1,0 +1,38 @@
+const { Base64 } = require('js-base64');
+const { AUTH_TYPES, createAuthorizationHeaderValue } = require('./auth');
+
+describe(createAuthorizationHeaderValue.name, () => {
+  test('should create the right base64 encoded header value for email/password auth', () => {
+    const authorizationHeaderValue = createAuthorizationHeaderValue({
+      authType: AUTH_TYPES.BASIC_AUTH,
+      email: 'test@example.com',
+      password: 'pa$$word',
+    });
+    expect(Base64.decode(authorizationHeaderValue.replace('Basic ', ''))).toBe('test@example.com:pa$$word');
+    expect(authorizationHeaderValue).toBe('Basic dGVzdEBleGFtcGxlLmNvbTpwYSQkd29yZA==');
+  });
+  test('should create the right base64 encoded header value for api token auth', () => {
+    const authorizationHeaderValue = createAuthorizationHeaderValue({
+      authType: AUTH_TYPES.API_TOKEN,
+      email: 'email@example.com',
+      zendeskAdminToken: 'XXXXX',
+    });
+    expect(Base64.decode(authorizationHeaderValue.replace('Basic ', ''))).toBe('email@example.com/token:XXXXX');
+    expect(authorizationHeaderValue).toBe('Basic ZW1haWxAZXhhbXBsZS5jb20vdG9rZW46WFhYWFg=');
+  });
+  test('should create the right header value for oauth', () => {
+    expect(
+      createAuthorizationHeaderValue({
+        authType: AUTH_TYPES.OAUTH_ACCESS_TOKEN,
+        zendeskAdminToken: 'XXXXX',
+      })
+    ).toBe('Bearer XXXXX');
+  });
+  test('should create a header for oauth if not specified otherwise', () => {
+    expect(
+      createAuthorizationHeaderValue({
+        zendeskAdminToken: 'XXXXX',
+      })
+    ).toBe('Bearer XXXXX');
+  });
+});

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -5,7 +5,7 @@ const { assertRequired } = require('../utils');
 const { AUTH_TYPES, createAuthorizationHeaderValue } = require('./auth');
 
 function assertRequiredFields(config) {
-  const { authType, zendeskSubdomain, email, password, zendeskAdminToken } = config;
+  const { authType = AUTH_TYPES.OAUTH_ACCESS_TOKEN, zendeskSubdomain, email, password, zendeskAdminToken } = config;
   assertRequired({ zendeskSubdomain });
 
   switch (authType) {
@@ -13,9 +13,14 @@ function assertRequiredFields(config) {
       return assertRequired({ email, password });
     case AUTH_TYPES.API_TOKEN:
       return assertRequired({ email, zendeskAdminToken });
-    default:
     case AUTH_TYPES.OAUTH_ACCESS_TOKEN:
       return assertRequired({ zendeskAdminToken });
+    default:
+      throw new Error(
+        `Invalid auth type authType: ${authType}, please require AUTH_TYPES and use one of ${Object.keys(AUTH_TYPES)
+          .map((key) => `AUTH_TYPES.${key}`)
+          .join(', ')}`
+      );
   }
 }
 

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -2,6 +2,22 @@ const walkSync = require('walk-sync');
 const Request = require('./request');
 const Response = require('./response');
 const { assertRequired } = require('../utils');
+const { AUTH_TYPES, createAuthorizationHeaderValue } = require('./auth');
+
+function assertRequiredFields(config) {
+  const { authType, zendeskSubdomain, email, password, zendeskAdminToken } = config;
+  assertRequired({ zendeskSubdomain });
+
+  switch (authType) {
+    case AUTH_TYPES.BASIC_AUTH:
+      return assertRequired({ email, password });
+    case AUTH_TYPES.API_TOKEN:
+      return assertRequired({ email, zendeskAdminToken });
+    default:
+    case AUTH_TYPES.OAUTH_ACCESS_TOKEN:
+      return assertRequired({ zendeskAdminToken });
+  }
+}
 
 function injectApiResources(api) {
   const projectRoot = `${__dirname}/../`;
@@ -16,8 +32,10 @@ function injectApiResources(api) {
 
 let api;
 
-module.exports = ({ zendeskSubdomain, zendeskAdminToken }) => {
-  assertRequired({ zendeskSubdomain, zendeskAdminToken });
+module.exports = (config) => {
+  const { zendeskSubdomain } = config;
+  assertRequiredFields(config);
+  const authHeader = createAuthorizationHeaderValue(config);
   api = api || {
     request: async (path, { method = 'GET', body, queryParams } = {}) => {
       const uri = `https://${zendeskSubdomain}.zendesk.com/api/v2/${path}`;
@@ -25,12 +43,14 @@ module.exports = ({ zendeskSubdomain, zendeskAdminToken }) => {
         method,
         body,
         queryParams,
-        auth: { zendeskSubdomain, zendeskAdminToken },
+        authHeader,
       });
 
-      return new Response(response, { auth: { zendeskSubdomain, zendeskAdminToken } });
+      return new Response(response, { authHeader });
     },
   };
 
   return injectApiResources(api);
 };
+
+module.exports.AUTH_TYPES = AUTH_TYPES;

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -139,6 +139,20 @@ describe('API', () => {
       }).toThrow('zendeskAdminToken is a required argument.');
     });
   });
+
+  describe('when auth method is via invalid', () => {
+    test('should initialise with defined resources', () => {
+      expect(() => {
+        Api({
+          zendeskSubdomain: 'my-subdomain',
+          zendeskAdminToken: 'XXXXX',
+          authType: 'INVALID_AUTH_TYPE',
+        });
+      }).toThrow(
+        'Invalid auth type authType: INVALID_AUTH_TYPE, please require AUTH_TYPES and use one of AUTH_TYPES.BASIC_AUTH, AUTH_TYPES.API_TOKEN, AUTH_TYPES.OAUTH_ACCESS_TOKEN'
+      );
+    });
+  });
 });
 
 describe('Api.request', () => {

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -1,34 +1,143 @@
 const nock = require('nock');
 const Api = require('./index');
+const { AUTH_TYPES } = require('./auth');
 
 describe('API', () => {
-  test('should initialise with defined resources', () => {
-    const supportedResources = ['tickets'];
+  describe('when auth method is via basic auth', () => {
+    test('should initialise with defined resources', () => {
+      const supportedResources = ['tickets', 'users'];
 
-    const zendeskApi = Api({
-      zendeskSubdomain: 'my-subdomain',
-      zendeskAdminToken: 'XXXXX',
+      const zendeskApi = Api({
+        authType: AUTH_TYPES.BASIC_AUTH,
+        zendeskSubdomain: 'my-subdomain',
+        email: 'email@example.com',
+        password: 'pa$$word',
+      });
+
+      supportedResources.forEach((resource) => {
+        expect(zendeskApi[resource]).toBeDefined();
+      });
     });
 
-    supportedResources.forEach((resource) => {
-      expect(zendeskApi[resource]).toBeDefined();
+    test('should throw an error if initialised without a subdomain', () => {
+      expect(() => {
+        Api({
+          authType: AUTH_TYPES.BASIC_AUTH,
+          email: 'email@example.com',
+          password: 'pa$$word',
+        });
+      }).toThrow('zendeskSubdomain is a required argument.');
+    });
+
+    test('should throw an error if initialised without an email', () => {
+      expect(() => {
+        Api({
+          authType: AUTH_TYPES.BASIC_AUTH,
+          zendeskSubdomain: 'my-subdomain',
+          password: 'pa$$word',
+        });
+      }).toThrow('email is a required argument.');
+    });
+
+    test('should throw an error if initialised without a password', () => {
+      expect(() => {
+        Api({
+          authType: AUTH_TYPES.BASIC_AUTH,
+          zendeskSubdomain: 'my-subdomain',
+          email: 'email@example.com',
+        });
+      }).toThrow('password is a required argument.');
     });
   });
 
-  test('should throw an error if initialised without a subdomain', () => {
-    expect(() => {
-      Api({
+  describe('when auth method is via api token', () => {
+    test('should initialise with defined resources', () => {
+      const supportedResources = ['tickets', 'users'];
+
+      const zendeskApi = Api({
+        authType: AUTH_TYPES.API_TOKEN,
+        zendeskSubdomain: 'my-subdomain',
+        email: 'email@example.com',
         zendeskAdminToken: 'XXXXX',
       });
-    }).toThrow('zendeskSubdomain is a required argument.');
+
+      supportedResources.forEach((resource) => {
+        expect(zendeskApi[resource]).toBeDefined();
+      });
+    });
+
+    test('should throw an error if initialised without a subdomain', () => {
+      expect(() => {
+        Api({
+          authType: AUTH_TYPES.API_TOKEN,
+          email: 'email@example.com',
+          zendeskAdminToken: 'XXXXX',
+        });
+      }).toThrow('zendeskSubdomain is a required argument.');
+    });
+
+    test('should throw an error if initialised without an email address', () => {
+      expect(() => {
+        Api({
+          authType: AUTH_TYPES.API_TOKEN,
+          zendeskSubdomain: 'my-subdomain',
+          zendeskAdminToken: 'XXXXX',
+        });
+      }).toThrow('email is a required argument.');
+    });
+
+    test('should throw an error if initialised without an adminToken', () => {
+      expect(() => {
+        Api({
+          authType: AUTH_TYPES.API_TOKEN,
+          zendeskSubdomain: 'my-subdomain',
+          email: 'email@example.com',
+        });
+      }).toThrow('zendeskAdminToken is a required argument.');
+    });
   });
 
-  test('should throw an error if initialised without an adminToken', () => {
-    expect(() => {
-      Api({
+  describe('when auth method is via oauth (default)', () => {
+    test('should initialise with defined resources', () => {
+      const supportedResources = ['tickets', 'users'];
+
+      const zendeskApiExplicitOauth = Api({
         zendeskSubdomain: 'my-subdomain',
+        zendeskAdminToken: 'XXXXX',
+        authType: AUTH_TYPES.OAUTH_ACCESS_TOKEN,
       });
-    }).toThrow('zendeskAdminToken is a required argument.');
+
+      supportedResources.forEach((resource) => {
+        expect(zendeskApiExplicitOauth[resource]).toBeDefined();
+      });
+
+      const zendeskApiImplicitOauth = Api({
+        zendeskSubdomain: 'my-subdomain',
+        zendeskAdminToken: 'XXXXX',
+      });
+
+      supportedResources.forEach((resource) => {
+        expect(zendeskApiImplicitOauth[resource]).toBeDefined();
+      });
+    });
+
+    test('should throw an error if initialised without a subdomain', () => {
+      expect(() => {
+        Api({
+          zendeskAdminToken: 'XXXXX',
+          authType: AUTH_TYPES.OAUTH_ACCESS_TOKEN,
+        });
+      }).toThrow('zendeskSubdomain is a required argument.');
+    });
+
+    test('should throw an error if initialised without an adminToken', () => {
+      expect(() => {
+        Api({
+          zendeskSubdomain: 'my-subdomain',
+          authType: AUTH_TYPES.OAUTH_ACCESS_TOKEN,
+        });
+      }).toThrow('zendeskAdminToken is a required argument.');
+    });
   });
 });
 

--- a/lib/api/request.js
+++ b/lib/api/request.js
@@ -13,7 +13,7 @@ function marshallBody(body) {
   return convertKeysToSnakeCase(body);
 }
 
-module.exports = function Request(uri, { method = 'GET', auth = {}, body = {}, queryParams = {} }) {
+module.exports = function Request(uri, { method = 'GET', authHeader = {}, body = {}, queryParams = {} }) {
   let qs;
   let processedBody;
 
@@ -25,8 +25,6 @@ module.exports = function Request(uri, { method = 'GET', auth = {}, body = {}, q
     processedBody = marshallBody(body);
   }
 
-  const { zendeskAdminToken } = auth;
-
   const options = {
     uri,
     method,
@@ -35,7 +33,7 @@ module.exports = function Request(uri, { method = 'GET', auth = {}, body = {}, q
     simple: false,
     resolveWithFullResponse: true,
     headers: {
-      Authorization: `Bearer ${zendeskAdminToken}`,
+      Authorization: authHeader,
       Accept: 'application/json',
     },
     json: true,

--- a/lib/api/request.test.js
+++ b/lib/api/request.test.js
@@ -13,9 +13,7 @@ describe('Request', () => {
 
     await new Request('https://example.com', {
       method: 'GET',
-      auth: {
-        zendeskAdminToken: 'abcdefg',
-      },
+      authHeader: 'abcdefg',
       queryParams: { camelCase: 'x', anotherOne: 'y' },
     });
 
@@ -28,7 +26,7 @@ describe('Request', () => {
       simple: false,
       resolveWithFullResponse: true,
       headers: {
-        Authorization: 'Bearer abcdefg',
+        Authorization: 'abcdefg',
         Accept: 'application/json',
       },
       json: true,
@@ -40,9 +38,7 @@ describe('Request', () => {
 
     await new Request('https://example.com', {
       method: 'GET',
-      auth: {
-        zendeskAdminToken: 'abcdefg',
-      },
+      authHeader: 'abcdefg',
       queryParams: { listData: ['x', 'y', 'z'] },
     });
 
@@ -54,7 +50,7 @@ describe('Request', () => {
       simple: false,
       resolveWithFullResponse: true,
       headers: {
-        Authorization: 'Bearer abcdefg',
+        Authorization: 'abcdefg',
         Accept: 'application/json',
       },
       json: true,
@@ -66,9 +62,7 @@ describe('Request', () => {
 
     await new Request('https://example.com', {
       method: 'GET',
-      auth: {
-        zendeskAdminToken: 'abcdefg',
-      },
+      authHeader: 'abcdefg',
       queryParams: {},
     });
 
@@ -80,7 +74,7 @@ describe('Request', () => {
       simple: false,
       resolveWithFullResponse: true,
       headers: {
-        Authorization: 'Bearer abcdefg',
+        Authorization: 'abcdefg',
         Accept: 'application/json',
       },
       json: true,
@@ -92,9 +86,7 @@ describe('Request', () => {
 
     await new Request('https://example.com', {
       method: 'GET',
-      auth: {
-        zendeskAdminToken: 'abcdefg',
-      },
+      authHeader: 'abcdefg',
       queryParams: { sortBy: 'updated_at', sortOrder: 'asc' },
     });
 
@@ -106,7 +98,7 @@ describe('Request', () => {
       simple: false,
       resolveWithFullResponse: true,
       headers: {
-        Authorization: 'Bearer abcdefg',
+        Authorization: 'abcdefg',
         Accept: 'application/json',
       },
       json: true,
@@ -118,9 +110,7 @@ describe('Request', () => {
 
     await new Request('https://example.com', {
       method: 'POST',
-      auth: {
-        zendeskAdminToken: 'abcdefg',
-      },
+      authHeader: 'abcdefg',
       body: { id: 1, name: 'A name' },
     });
 
@@ -132,7 +122,7 @@ describe('Request', () => {
       simple: false,
       resolveWithFullResponse: true,
       headers: {
-        Authorization: 'Bearer abcdefg',
+        Authorization: 'abcdefg',
         Accept: 'application/json',
       },
       json: true,
@@ -144,9 +134,7 @@ describe('Request', () => {
 
     await new Request('https://example.com', {
       method: 'PUT',
-      auth: {
-        zendeskAdminToken: 'abcdefg',
-      },
+      authHeader: 'abcdefg',
       body: { id: 1, name: 'A name' },
     });
 
@@ -158,7 +146,7 @@ describe('Request', () => {
       simple: false,
       resolveWithFullResponse: true,
       headers: {
-        Authorization: 'Bearer abcdefg',
+        Authorization: 'abcdefg',
         Accept: 'application/json',
       },
       json: true,
@@ -170,9 +158,7 @@ describe('Request', () => {
 
     await new Request('https://example.com', {
       method: 'PATCH',
-      auth: {
-        zendeskAdminToken: 'abcdefg',
-      },
+      authHeader: 'abcdefg',
       body: { id: 1, name: 'A name' },
     });
 
@@ -184,7 +170,7 @@ describe('Request', () => {
       simple: false,
       resolveWithFullResponse: true,
       headers: {
-        Authorization: 'Bearer abcdefg',
+        Authorization: 'abcdefg',
         Accept: 'application/json',
       },
       json: true,

--- a/lib/api/response.js
+++ b/lib/api/response.js
@@ -2,7 +2,7 @@ const Request = require('./request');
 const { convertKeysToCamelCase } = require('../utils');
 const { ZendeskRequestError } = require('./errors');
 
-function Response(response = {}, { auth } = {}) {
+function Response(response = {}, { authHeader } = {}) {
   const body = convertKeysToCamelCase(response.body);
 
   function pageGetterFactory(pageUrl) {
@@ -10,8 +10,8 @@ function Response(response = {}, { auth } = {}) {
       return null;
     }
     return async () => {
-      const data = await new Request(pageUrl, { auth });
-      return new Response(data, { auth });
+      const data = await new Request(pageUrl, { authHeader });
+      return new Response(data, { authHeader });
     };
   }
 

--- a/lib/resources/users.js
+++ b/lib/resources/users.js
@@ -1,0 +1,7 @@
+module.exports = ({ api }) => {
+  api.users = {
+    autocomplete: (queryParams) => api.request(`users/autocomplete.json`, { queryParams }),
+  };
+
+  return api;
+};

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "camel-case": "^3.0.0",
+    "js-base64": "^2.5.1",
     "request-promise": "^4.2.4",
     "snake-case": "^2.1.0",
     "walk-sync": "^1.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zendesk-node",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Node Wrapper for Zendesk V2 API",
   "repository": "https://github.com/hostmakerco/zendesk-node-sdk.git",
   "main": "lib/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,6 +2730,11 @@ jest@^24.7.1:
     import-local "^2.0.0"
     jest-cli "^24.7.1"
 
+js-base64@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
+  integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Adds support for
 - [Basic authentication](https://developer.zendesk.com/rest_api/docs/support/introduction#basic-authentication)
 - [API token](https://developer.zendesk.com/rest_api/docs/support/introduction#api-token)

Also extended the README.