### PR TITLE
Added option to auth without base64

### DIFF
--- a/lib/api/auth.js
+++ b/lib/api/auth.js
@@ -7,13 +7,17 @@ const AUTH_TYPES = {
 };
 
 function createAuthorizationHeaderValue(config) {
-  const { authType, email, password, zendeskAdminToken } = config;
+  const { authType, email, password, zendeskAdminToken, encodeEmailAndToken = true } = config;
 
   switch (authType) {
     case AUTH_TYPES.BASIC_AUTH:
       return `Basic ${Base64.btoa(`${email}:${password}`)}`;
     case AUTH_TYPES.API_TOKEN:
-      return `Basic ${Base64.btoa(`${email}/token:${zendeskAdminToken}`)}`;
+      if (encodeEmailAndToken) {
+        return `Basic ${Base64.btoa(`${email}/token:${zendeskAdminToken}`)}`;
+      } else {
+        return `Basic ${zendeskAdminToken}`;
+      }
     default:
     case AUTH_TYPES.OAUTH_ACCESS_TOKEN:
       return `Bearer ${zendeskAdminToken}`;

--- a/lib/api/auth.js
+++ b/lib/api/auth.js
@@ -15,9 +15,8 @@ function createAuthorizationHeaderValue(config) {
     case AUTH_TYPES.API_TOKEN:
       if (encodeEmailAndToken) {
         return `Basic ${Base64.btoa(`${email}/token:${zendeskAdminToken}`)}`;
-      } else {
-        return `Basic ${zendeskAdminToken}`;
       }
+      return `Basic ${zendeskAdminToken}`;
     default:
     case AUTH_TYPES.OAUTH_ACCESS_TOKEN:
       return `Bearer ${zendeskAdminToken}`;

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -5,14 +5,17 @@ const { assertRequired } = require('../utils');
 const { AUTH_TYPES, createAuthorizationHeaderValue } = require('./auth');
 
 function assertRequiredFields(config) {
-  const { authType = AUTH_TYPES.OAUTH_ACCESS_TOKEN, zendeskSubdomain, email, password, zendeskAdminToken } = config;
+  const { authType = AUTH_TYPES.OAUTH_ACCESS_TOKEN, zendeskSubdomain, email, password, zendeskAdminToken, encodeEmailAndToken } = config;
   assertRequired({ zendeskSubdomain });
 
   switch (authType) {
     case AUTH_TYPES.BASIC_AUTH:
       return assertRequired({ email, password });
     case AUTH_TYPES.API_TOKEN:
-      return assertRequired({ email, zendeskAdminToken });
+      if (encodeEmailAndToken) {
+        return assertRequired({ email, zendeskAdminToken });
+      }
+      return assertRequired({ zendeskAdminToken });
     case AUTH_TYPES.OAUTH_ACCESS_TOKEN:
       return assertRequired({ zendeskAdminToken });
     default:


### PR DESCRIPTION
So that we could do this:
```javascript
createAuthorizationHeaderValue({
  authType: 'API_TOKEN',
  zendeskAdminToken: 'SOME_ALREADY_ENCODED_TOKEN',
})
```
And use an already encoded email+token from the credentials file.
Otherwise we have to store token + email in credential files.