### PR TITLE
Add auth method for base64 encoded tokens

### DIFF
--- a/lib/api/auth.js
+++ b/lib/api/auth.js
@@ -19,7 +19,7 @@ function createAuthorizationHeaderValue(config) {
       return `Basic ${zendeskAdminToken}`;
     default:
     case AUTH_TYPES.OAUTH_ACCESS_TOKEN:
-      return `Bearer ${zendeskAdminToken}`; 
+      return `Bearer ${zendeskAdminToken}`;
   }
 }
 

--- a/lib/api/auth.js
+++ b/lib/api/auth.js
@@ -4,6 +4,7 @@ const AUTH_TYPES = {
   BASIC_AUTH: 'BASIC_AUTH',
   API_TOKEN: 'API_TOKEN',
   OAUTH_ACCESS_TOKEN: 'OAUTH_ACCESS_TOKEN',
+  API_TOKEN_BASE64_ENCODED: 'API_TOKEN_BASE64_ENCODED',
 };
 
 function createAuthorizationHeaderValue(config) {
@@ -14,6 +15,8 @@ function createAuthorizationHeaderValue(config) {
       return `Basic ${Base64.btoa(`${email}:${password}`)}`;
     case AUTH_TYPES.API_TOKEN:
       return `Basic ${Base64.btoa(`${email}/token:${zendeskAdminToken}`)}`;
+    case AUTH_TYPES.API_TOKEN_BASE64_ENCODED:
+        return `Basic ${zendeskAdminToken}`;
     default:
     case AUTH_TYPES.OAUTH_ACCESS_TOKEN:
       return `Bearer ${zendeskAdminToken}`;

--- a/lib/api/auth.js
+++ b/lib/api/auth.js
@@ -16,10 +16,10 @@ function createAuthorizationHeaderValue(config) {
     case AUTH_TYPES.API_TOKEN:
       return `Basic ${Base64.btoa(`${email}/token:${zendeskAdminToken}`)}`;
     case AUTH_TYPES.API_TOKEN_BASE64_ENCODED:
-        return `Basic ${zendeskAdminToken}`;
+      return `Basic ${zendeskAdminToken}`;
     default:
     case AUTH_TYPES.OAUTH_ACCESS_TOKEN:
-      return `Bearer ${zendeskAdminToken}`;
+      return `Bearer ${zendeskAdminToken}`; 
   }
 }
 

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -15,6 +15,8 @@ function assertRequiredFields(config) {
       return assertRequired({ email, zendeskAdminToken });
     case AUTH_TYPES.OAUTH_ACCESS_TOKEN:
       return assertRequired({ zendeskAdminToken });
+    case AUTH_TYPES.API_TOKEN_BASE64_ENCODED:
+      return assertRequired({ zendeskAdminToken });
     default:
       throw new Error(
         `Invalid auth type authType: ${authType}, please require AUTH_TYPES and use one of ${Object.keys(AUTH_TYPES)

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -140,6 +140,14 @@ describe('API', () => {
     });
   });
 
+  describe('when auth method is via base64 encoded token with email', () => {
+    test('should throw an error if initialised without an adminToken', () => {
+      expect(() => {
+        Api({ authType: AUTH_TYPES.API_TOKEN_BASE64_ENCODED });
+      }).toThrow('zendeskAdminToken is a required argument.');
+    });
+  });
+
   describe('when auth method is via invalid', () => {
     test('should initialise with defined resources', () => {
       expect(() => {

--- a/lib/api/index.test.js
+++ b/lib/api/index.test.js
@@ -143,7 +143,10 @@ describe('API', () => {
   describe('when auth method is via base64 encoded token with email', () => {
     test('should throw an error if initialised without an adminToken', () => {
       expect(() => {
-        Api({ authType: AUTH_TYPES.API_TOKEN_BASE64_ENCODED });
+        Api({
+          zendeskSubdomain: 'my-subdomain',
+          authType: AUTH_TYPES.API_TOKEN_BASE64_ENCODED,
+        });
       }).toThrow('zendeskAdminToken is a required argument.');
     });
   });


### PR DESCRIPTION
If you want to auth with zendesk api tokens, you have to have an email and a token to generate a base64 encoded token.
So, this PR enables using the base64 encoded token instead of email+token to authenticate.